### PR TITLE
Use esxcli instead of df to list volumes

### DIFF
--- a/lib/vagrant-vmware-esxi/action/createvm.rb
+++ b/lib/vagrant-vmware-esxi/action/createvm.rb
@@ -79,8 +79,8 @@ module VagrantPlugins
             #
             #  Figure out DataStore
             r = ssh.exec!(
-                    'df 2>/dev/null| grep "^[VMFS|NFS].*/vmfs/volumes/" | '\
-                    'sort -nk4 | sed "s|.*/vmfs/volumes/||g"')
+                    'esxcli storage filesystem list | grep /vmfs/volumes/ | '\
+                    'cut -d " " -f3')
 
             availvolumes = r.split(/\n/)
             if config.debug =~ %r{true}i


### PR DESCRIPTION
On my ESXi server, `df` command returns:
```
# df
Traceback (most recent call last):
  File "/sbin/df", line 99, in <module>
    sys.exit(main(sys.argv))
  File "/sbin/df", line 53, in main
    o = eval(output)
  File "<string>", line 1
    Errors:
          ^
SyntaxError: invalid syntax
```

[It turns out](https://communities-gbot.vmware.com/thread/439334) this is related to some `Input/output error`. However, `esxcli storage filesystem list` command doesn't fail in this case, so what do you think about using this one instead?