### PR TITLE
Added feature - Extend original disk provision

### DIFF
--- a/lib/vagrant-vmware-esxi/config.rb
+++ b/lib/vagrant-vmware-esxi/config.rb
@@ -18,6 +18,7 @@ module VagrantPlugins
       attr_accessor :guest_guestos
       attr_accessor :guest_disk_type
       attr_accessor :guest_storage
+      attr_accessor :guest_extend_main_disk_size
       attr_accessor :guest_nic_type
       attr_accessor :guest_mac_address
       attr_accessor :guest_memsize
@@ -74,6 +75,7 @@ module VagrantPlugins
         @guest_guestos = nil
         @guest_disk_type = nil
         @guest_storage = nil
+        @guest_extend_main_disk_size = nil
         @guest_nic_type = nil
         @guest_mac_address = ["","","",""]
         @guest_memsize = nil


### PR DESCRIPTION
This pull request updates config.rb and createvm.rb to allow the user to extend the original disk provision for the vmdk. 

How to run in the Vagrantfile:
__________________________________________________________
config.vm.provider: vmware_esxi do | esxi, override |
	.
	.
	esxi.guest_extend_main_disk_size = 77
	.
	.
end
__________________________________________________________
This pr/contribution was tested before submission: (Testing that was done)
Executing with the following "esxi.guest_extend_main_disk_size = 77" 
Executing without the parameter "#esxi.guest_extend_main_disk_size = 77"
