### PR TITLE
Allow datastores with spaces

### DIFF
--- a/lib/vagrant-vmware-esxi/action/createvm.rb
+++ b/lib/vagrant-vmware-esxi/action/createvm.rb
@@ -139,7 +139,7 @@ module VagrantPlugins
             #  Figure out DataStore
             r = ssh.exec!(
                     'esxcli storage filesystem list | grep "/vmfs/volumes/.*[VMFS|NFS]" | '\
-                    "sort -nk7 | awk '{print $2}'")
+                    "sort -nk7 | awk -F"  " '{print $2}'")
 
             availvolumes = r.split(/\n/)
             if config.debug =~ %r{true}i


### PR DESCRIPTION
I had a problem using a datastore with spaces in the name. This change seems to allow datastores with spaces in the name.