### PR TITLE
Corrected number of networks created

### DIFF
--- a/lib/vagrant-vmware-esxi/action/createvm.rb
+++ b/lib/vagrant-vmware-esxi/action/createvm.rb
@@ -244,6 +244,9 @@ module VagrantPlugins
               next if type != :private_network && type != :public_network
               vm_network_index += 1
             end
+            if vm_network_index > 0
+              vm_network_index -= 1
+            end
 
             #  If there is more vm.network than esxi_virtual_network's configured
             #  I need to add more esxi_virtual_networks.  Setting each to ---NotSet---


### PR DESCRIPTION
When networks were being created the plugin would create an additional one. I modified the code to only create the number of networks specified within the vagrant file