### PR TITLE
Shorten package name

### DIFF
--- a/lib/vagrant-vmware-esxi/action/package.rb
+++ b/lib/vagrant-vmware-esxi/action/package.rb
@@ -43,7 +43,7 @@ module VagrantPlugins
               overwrite_opts = nil
             end
 
-            boxname = env['package.output'].gsub('/', '-VAGRANTSLASH-')
+            boxname = env['package.output'].split("/").last.chomp(".box")
             tmpdir = "ZZZZ_tmpdir"
             Dir.mkdir(tmpdir) unless File.exists?(tmpdir)
 


### PR DESCRIPTION
When packaging a box with a long path, it will fail at tarring:

```
$ vagrant package --output /home/user/thing/projects/subdir/myvm.box myvm

==> myvm: --- Attempting to package
==> myvm: --- boxname: -VAGRANTSLASH-home-VAGRANTSLASH-user-VAGRANTSLASH-thing-VAGRANTSLASH-projects-VAGRANTSLASH-subdir-VAGRANTSLASH-myvm.box.box
VMware ovftool 4.3.0 (build-10104578)
Opening VI source: vi://root@192.168.1.1:443/
Opening VMX target: ZZZZ_tmpdir
Writing VMX file: ZZZZ_tmpdir/-VAGRANTSLASH-home-VAGRANTSLASH-user-VAGRANTSLASH-thing-VAGRANTSLASH-projects-VAGRANTSLASH-subdir-VAGRANTSLASH-myvm.box/-VAGRANTSLASH-home-VAGRANTSLASH-user-VAGRANTSLASH-thing-VAGRANTSLASH-projects-VAGRANTSLASH-subdir-VAGRANTSLASH-myvm.box.vmx
Transfer Completed
Completed successfully
==> myvm: tarring -VAGRANTSLASH-home-VAGRANTSLASH-user-VAGRANTSLASH-thing-VAGRANTSLASH-projects-VAGRANTSLASH-subdir-VAGRANTSLASH-myvm.box.box
tar: AGRANTSLASH-home-VAGRANTSLASH-user-VAGRANTSLASH-thing-VAGRANTSLASH-projects-VAGRANTSLASH-subdir-VAGRANTSLASH-myvm.box.vmx: Volume label is too long (limit is 99 bytes)
Try 'tar --help' or 'tar --usage' for more information.
```

This PR makes `package` works similarly to virtualbox provider, eg:

```
$ vagrant package --output /home/user/thing/projects/subdir/myvm.box myvm
==> kali: Clearing any previously set forwarded ports...
==> kali: Exporting VM...
==> kali: Compressing package to: /home/user/thing/projects/subdir/myvm.box

```
