### PR TITLE
Disable "MacNaming" on vagrant package

### DIFF
--- a/lib/vagrant-vmware-esxi/action/package.rb
+++ b/lib/vagrant-vmware-esxi/action/package.rb
@@ -92,7 +92,7 @@ module VagrantPlugins
                              '  install from http://www.vmware.com.'
             end
 
-            ovf_cmd = "ovftool --noSSLVerify -tt=VMX --name=\"#{boxname}\" "\
+            ovf_cmd = "ovftool --noSSLVerify -tt=VMX --X:useMacNaming=false --name=\"#{boxname}\" "\
                       "#{overwrite_opts} vi://#{config.esxi_username}:"\
                       "#{config.encoded_esxi_password}@#{config.esxi_hostname}"\
                       "?moref=vim.VirtualMachine:#{machine.id} #{tmpdir}"


### PR DESCRIPTION
Related to https://github.com/josenk/vagrant-vmware-esxi/issues/30, when running `vagrant package` OVFTool also adds the `vmwarevm` suffix to the directory name.