### PR TITLE
Use port groups and vSwitches for networking

### DIFF
--- a/lib/vagrant-vmware-esxi.rb
+++ b/lib/vagrant-vmware-esxi.rb
@@ -1,4 +1,5 @@
 require 'pathname'
+require 'vagrant-vmware-esxi/ext'
 require 'vagrant-vmware-esxi/plugin'
 
 module VagrantPlugins

--- a/lib/vagrant-vmware-esxi/action.rb
+++ b/lib/vagrant-vmware-esxi/action.rb
@@ -140,6 +140,18 @@ module VagrantPlugins
             b1.use Halt unless env1[:machine_state] == 'powered_off'
             b1.use ReadState
             b1.use Destroy
+            b1.use DestroyUnusedNetworks
+          end
+        end
+      end
+
+      def self.action_destroy_networks
+        Vagrant::Action::Builder.new.tap do |b|
+          b.use SetESXiPassword
+          b.use Call, DestroyUnusedNetworksConfirm do |env1, b1|
+            if env1[:result]
+              b1.use DestroyUnusedNetworks
+            end
           end
         end
       end
@@ -164,6 +176,7 @@ module VagrantPlugins
           b.use ConfigValidate
           b.use HandleBox
           b.use ReadState
+          b.use CreateNetwork
           b.use CreateVM
           b.use ReadState
           b.use Boot
@@ -203,6 +216,7 @@ module VagrantPlugins
       action_root = Pathname.new(File.expand_path('../action', __FILE__))
       autoload :SetESXiPassword, action_root.join('esxi_password')
       autoload :CreateVM, action_root.join('createvm')
+      autoload :CreateNetwork, action_root.join('create_network')
       autoload :ReadState, action_root.join('read_state')
       autoload :ReadSSHInfo, action_root.join('read_ssh_info')
       autoload :SetNetworkIP, action_root.join('set_network_ip')
@@ -210,6 +224,8 @@ module VagrantPlugins
       autoload :Halt, action_root.join('halt')
       autoload :Shutdown, action_root.join('shutdown')
       autoload :Destroy, action_root.join('destroy')
+      autoload :DestroyUnusedNetworks, action_root.join('destroy_unused_networks')
+      autoload :DestroyUnusedNetworksConfirm, action_root.join('destroy_unused_networks_confirm')
       autoload :Suspend, action_root.join('suspend')
       autoload :Resume, action_root.join('resume')
       autoload :Package, action_root.join('package')

--- a/lib/vagrant-vmware-esxi/action/create_network.rb
+++ b/lib/vagrant-vmware-esxi/action/create_network.rb
@@ -1,0 +1,171 @@
+require 'json'
+require 'vagrant-vmware-esxi/util/esxcli'
+
+module VagrantPlugins
+  module ESXi
+    module Action
+      # Automatically create network (Port group/VLAN) per subnet
+      #
+      # For example, when a box given 192.168.1.10/24, create 192.168.1.0/24 port group.
+      # Then, when another box is given 192.168.1.20/24, use the same port group from
+      # the previous one.
+      #
+      # Example configuration:
+      #   config.vm.network "private_network", ip: "192.168.10.170", netmask: "255.255.255.0",
+      #
+      # This will create port group '{vSwitchName}-192.168.10.0-24'.
+      #
+      # You can also use manual configurations for the vSwitch and the port group, such as:
+      #   config.vm.network "private_network", ip: "192.168.10.170", netmask: "255.255.255.0",
+      #     esxi__vswitch: "Internal Switch", esxi__port_group: "Internal Network"
+      #
+      # Notes:
+      # 1. If you specify only esxi__port_group, a new port group will be created on the default_vswitch if
+      # not already created. If you specify only esxi__vswitch, the default_port_group will be used, and
+      # it will error if there's a mismatch. In this case, you should probably specify both.
+      # 2. If you specify both esxi__port_group and esxi__vswitch, a new port group will be created
+      # on that vSwitch if not already created.
+      #
+      # For (1) and (2), the vSwitch will also be created if not already created. In any case,
+      # if esxi__port_group already exists, the esxi__vswitch is ignored (not in the VMX file).
+      class CreateNetwork
+        include Util::ESXCLI
+
+        CREATE_NETWORK_MUTEX = Mutex.new
+
+        MAX_VLAN = 4094
+        VLANS = Array.new(MAX_VLAN) { |i| i + 1 }.freeze
+
+        def initialize(app, env)
+          @app = app
+          @logger = Log4r::Logger.new('vagrant_vmware_esxi::action::create_network')
+        end
+
+        def call(env)
+          @env = env
+          @default_vswitch = env[:machine].provider_config.default_vswitch
+          @default_port_group = env[:machine].provider_config.default_port_group
+          create_network
+          @app.call(env)
+        end
+
+        def create_network
+          CREATE_NETWORK_MUTEX.synchronize do
+            @env[:ui].info I18n.t("vagrant_vmware_esxi.vagrant_vmware_esxi_message",
+                                  message: "Default network on Adapter 1: vSwitch: #{@default_vswitch}, "\
+                                  "port group: #{@default_port_group}")
+            @env[:ui].info I18n.t("vagrant_vmware_esxi.vagrant_vmware_esxi_message",
+                                  message: "Creating other networks...")
+            @created_vswitches = []
+            @created_port_groups = []
+
+            connect_ssh do
+              @env[:machine].config.vm.networks.each.with_index do |(type, network_options), index|
+                adapter = index + 2
+                next if type != :private_network && type != :public_network
+                set_network_configs(adapter, type, network_options)
+                create_vswitch_unless_created(network_options)
+                create_port_group_unless_created(network_options)
+
+                details = "vSwitch: #{network_options[:esxi__vswitch]}, "\
+                  "port group: #{network_options[:esxi__port_group]}"
+                @env[:ui].detail I18n.t("vagrant_vmware_esxi.vagrant_vmware_esxi_message",
+                                        message: "Adapter #{adapter}: #{details}")
+              end
+            end
+
+            save_created_networks
+          end
+        end
+
+        def set_network_configs(adapter, type, network_options)
+          # TODO Does this matter? we don't really care where default_vswitch is bridged to anyway
+          # Assume public_network is using provider_config default_vswitch and default_port_group
+          private_network_configs = [:esxi__vswitch, :esxi__port_group, :dhcp] & network_options.keys
+          if type == :public_network && private_network_configs.any?
+            raise Errors::ESXiError,
+              message: "Setting #{private_network_configs.join(', ')} not allowed for `public_network`."
+          end
+
+          custom_vswitch = true if network_options[:esxi__vswitch]
+          dhcp = network_options[:type] == "dhcp" || !network_options[:ip]
+          network_options[:esxi__vswitch] ||= @default_vswitch
+          network_options[:netmask] ||= 24 unless dhcp
+
+          network_options[:esxi__port_group] ||=
+            if custom_vswitch || dhcp
+              @default_port_group
+            else
+              # Use the address to generate the port_group name
+              ip = IPAddr.new("#{network_options[:ip]}/#{network_options[:netmask]}")
+              "#{network_options[:esxi__vswitch]}-#{ip.to_s}-#{ip.prefix}"
+            end
+        end
+
+        def create_vswitch_unless_created(network_options)
+          @logger.info("Creating vSwitch '#{network_options[:esxi__vswitch]}' if not yet created")
+
+          vswitch = network_options[:esxi__vswitch]
+          unless has_vswitch? vswitch
+            if create_vswitch(vswitch)
+              @created_vswitches << vswitch
+            else
+              raise Errors::ESXiError, message: "Unable create new vSwitch '#{vswitch}'."
+            end
+          end
+        end
+
+        def create_port_group_unless_created(network_options)
+          port_groups = get_port_groups
+          @logger.debug("Port groups: #{port_groups}")
+
+          if port_group = port_groups[network_options[:esxi__port_group]]
+            # port group already created
+            unless port_group[:vswitch] == network_options[:esxi__vswitch]
+              raise Errors::ESXiError, message: "Existing port group '#{network_options[:esxi__port_group]}' "\
+                "must be in vSwitch '#{network_options[:esxi__vswitch]}'"
+            end
+
+            return
+          end
+
+          # VLAN 0 is bridged to physical NIC by default
+          vlan_ids = port_groups.values.map { |v| v[:vlan] }.uniq.sort - [0]
+          vlan = (VLANS - vlan_ids).first
+          unless vlan
+            raise Errors::ESXiError,
+              message: "No more VLAN (max: #{MAX_VLAN}) to assign to the port group"
+          end
+
+          # TODO check max port groups per vSwitch (512)
+
+          vswitch = network_options[:esxi__vswitch] || @default_vswitch
+          @logger.info("Creating port group #{network_options[:esxi__port_group]} on vSwitch '#{vswitch}'")
+          unless create_port_group(network_options[:esxi__port_group], vswitch, vlan)
+            raise Errors::ESXiError, message: "Cannot create port group "\
+              "`#{network_options[:esxi__port_group]}`, VLAN #{vlan}"
+          end
+
+          @created_port_groups << network_options[:esxi__port_group]
+        end
+
+        # Save networks created by this action
+        def save_created_networks
+          @logger.debug("Save created networks")
+          file = @env[:machine].data_dir.join("networks")
+
+          if file.exist?
+            json = JSON.parse(file.read) 
+            @logger.debug("Previously saved networks: #{json}")
+            json["port_groups"] = json["port_groups"].concat(@created_port_groups.uniq).uniq
+            json["vswitches"] = json["vswitches"].concat(@created_vswitches.uniq).uniq
+          else
+            json = { port_groups: @created_port_groups.uniq, vswitches: @created_vswitches.uniq }
+          end
+
+          File.write(file, JSON.generate(json))
+        end
+      end
+    end
+  end
+end

--- a/lib/vagrant-vmware-esxi/action/destroy_unused_networks.rb
+++ b/lib/vagrant-vmware-esxi/action/destroy_unused_networks.rb
@@ -1,0 +1,116 @@
+require 'vagrant-vmware-esxi/util/esxcli'
+
+module VagrantPlugins
+  module ESXi
+    module Action
+      class DestroyUnusedNetworks
+        include Util::ESXCLI
+
+        IP_RE = '(\d{1,3}\.){3}\d{1,3}'
+        IP_PREFIX_RE = '\d{1,2}'
+
+        def initialize(app, env)
+          @app = app
+          @scope = env[:scope]
+          @logger = Log4r::Logger.new('vagrant_vmware_esxi::action::destroy_unused_networks')
+        end
+
+        def call(env)
+          @env = env
+          @vmid = env[:machine].id
+          connect_ssh { destroy_networks }
+          @app.call(env)
+        end
+
+        def destroy_networks
+          if @scope == :all
+            # Destroy ALL unused auto port groups, including the ones created by another `vagrant up`,
+            # which match pattern such as:
+            #   vSwitch0-192.168.100.0-24 ({vswitch}-{net-address}-{prefix})
+            # This WON'T destroy any vSwitches 
+            destroy_unused_auto_port_groups
+          else
+            # Destroy unused port groups that were created by this `vagrant up` 
+            destroy_unused_port_groups if @env[:machine].provider_config.destroy_unused_port_groups
+            destroy_unused_vswitches if @env[:machine].provider_config.destroy_unused_vswitches
+          end
+        end
+
+        def destroy_unused_auto_port_groups
+          vswitch = @env[:machine].provider_config.default_vswitch
+          @env[:ui].info I18n.t("vagrant_vmware_esxi.vagrant_vmware_esxi_message",
+                                message: "Destroying unused auto port groups on vswitch '#{vswitch}'...")
+
+          active_port_groups = get_active_port_group_names
+          @logger.debug("active port groups: #{active_port_groups}")
+          get_port_groups.each do |name, port_group|
+            if auto_port_group_re.match?(name) && !active_port_groups.include?(name)
+              destroy_unused_port_group(name, port_group[:vswitch])
+            end
+          end
+        end
+
+        def destroy_unused_port_groups
+          @env[:ui].info I18n.t("vagrant_vmware_esxi.vagrant_vmware_esxi_message",
+                                message: "Destroying unused port groups that were created automatically...")
+
+          all_port_groups = get_port_groups
+          active_port_groups = get_active_port_group_names
+          @logger.debug("all port groups: #{all_port_groups.inspect}")
+          @logger.debug("active port groups: #{active_port_groups}")
+          created_networks["port_groups"].each do |port_group|
+            found = all_port_groups[port_group]
+            unless active_port_groups.include? port_group
+              destroy_unused_port_group(port_group, found[:vswitch])
+            end
+          end
+        end
+
+        def destroy_unused_port_group(port_group, vswitch)
+          @env[:ui].detail I18n.t("vagrant_vmware_esxi.vagrant_vmware_esxi_message",
+                                message: "Destroying port group '#{port_group}'")
+          unless remove_port_group(port_group, vswitch)
+            raise Errors::ESXiError, message: "Unable to remove port group '#{port_group}'"
+          end
+        end
+
+        def destroy_unused_vswitches
+          @env[:ui].info I18n.t("vagrant_vmware_esxi.vagrant_vmware_esxi_message",
+                                message: "Destroying unused vSwitches that were created automatically...")
+
+          @logger.debug("all port groups: #{created_networks["vswitches"].inspect}")
+          created_networks["vswitches"].each do |vswitch|
+            if get_vswitch_port_group_names(vswitch).empty?
+              destroy_unused_vswitch(vswitch)
+            end
+          end
+        end
+
+        def destroy_unused_vswitch(vswitch)
+          @env[:ui].detail I18n.t("vagrant_vmware_esxi.vagrant_vmware_esxi_message",
+                                  message: "Destroying vswitch '#{vswitch}'")
+          unless remove_vswitch(vswitch)
+            raise Errors::ESXiError, message: "Unable to remove vswitch '#{vswitch}'"
+          end
+        end
+
+        def created_networks
+          @created_networks ||= (
+            file = @env[:machine].data_dir.join("networks")
+            if file.exist?
+              JSON.parse(File.read(file))
+            else
+              { "port_groups" => [], "vswitches" => [] }
+            end
+          )
+        end
+
+        def auto_port_group_re
+          vswitch = Regexp.escape(@env[:machine].provider_config.default_vswitch)
+
+          @auto_port_group_re ||= /^#{vswitch}-#{IP_RE}-#{IP_PREFIX_RE}$/
+        end
+      end
+    end
+  end
+end

--- a/lib/vagrant-vmware-esxi/action/destroy_unused_networks_confirm.rb
+++ b/lib/vagrant-vmware-esxi/action/destroy_unused_networks_confirm.rb
@@ -1,0 +1,18 @@
+require "vagrant/action/builtin/confirm"
+
+module VagrantPlugins
+  module ESXi
+    module Action
+      class DestroyUnusedNetworksConfirm < Confirm
+        def initialize(app, env)
+          force_key = :force_confirm_destroy_networks
+          # message   = I18n.t("vagrant.commands.destroy.confirmation",
+                             # name: env[:machine].name)
+          message = "Destroy all networks? "
+
+          super(app, env, message, force_key, allowed: ["y", "n", "Y", "N"])
+        end
+      end
+    end
+  end
+end

--- a/lib/vagrant-vmware-esxi/action/set_network_ip.rb
+++ b/lib/vagrant-vmware-esxi/action/set_network_ip.rb
@@ -23,98 +23,38 @@ module VagrantPlugins
         def set_network_ip(env)
           @logger.info('vagrant-vmware-esxi, set_network_ip: start...')
 
-          # Get config.
-          @env = env
-          machine = env[:machine]
-          config = env[:machine].provider_config
-
-          #  Number of nics configured
-          if config.esxi_virtual_network.is_a? Array
-            number_of_adapters = config.esxi_virtual_network.count
-          else
-            number_of_adapters = 1
-          end
-
-          #
-          #  Make an array of vm.network settings (from Vagrantfile).
-          #  One index for each network interface. I'll use private_network and
-          #  public_network as both valid.   Since it would be a TERRIBLE idea
-          #  to modify ESXi virtual network configurations, I'll just set the IP
-          #  using static or DHCP.   Everything else will be ignored...
-          #
-          vm_network = []
-          env[:machine].config.vm.networks.each do |type, options|
-            # I only handle private and public networks
-            next if type != :private_network && type != :public_network
-            next if vm_network.count >= number_of_adapters
-            vm_network << options
-          end
-
-
-          if (config.debug =~ %r{true}i)
-            puts "num adapters: #{number_of_adapters},  vm.network.count: #{vm_network.count}"
-          end
-
           networks_to_configure = []
-          if (number_of_adapters > 1) and (vm_network.count > 0)
-            1.upto(number_of_adapters - 1) do |index|
-              if !vm_network[index - 1].nil?
-                options = vm_network[index - 1]
-                next if options[:auto_config] === false
-                if options[:ip]
-                  ip_class = options[:ip].gsub(/\..*$/,'').to_i
-                  if ip_class < 127
-                    class_netmask = '255.0.0.0'
-                  elsif ip_class > 127 and ip_class < 192
-                    class_netmask = '255.255.0.0'
-                  elsif ip_class >= 192 and ip_class <= 223
-                    class_netmask = '255.255.255.0'
-                  end
 
-                  # if netmask is not specified or is invalid, use, class defaults
-                  unless options[:netmask]
-                     netmask = class_netmask
-                  else
-                    netmask = options[:netmask]
-                  end
-                  unless netmask =~ /^(((128|192|224|240|248|252|254)\.0\.0\.0)|(255\.(0|128|192|224|240|248|252|254)\.0\.0)|(255\.255\.(0|128|192|224|240|248|252|254)\.0)|(255\.255\.255\.(0|128|192|224|240|248|252|254)))$/i
-                    env[:ui].info I18n.t('vagrant_vmware_esxi.vagrant_vmware_esxi_message',
-                                         message: "WARNING         : Invalid netmask specified, using Class mask (#{class_netmask})")
-                    netmask = class_netmask
-                  end
-                  network = {
-                    interface: index,
-                    type: :static,
-                    use_dhcp_assigned_default_route: options[:use_dhcp_assigned_default_route],
-                    guest_mac_address: options[:mac],
-                    ip: options[:ip],
-                    netmask: netmask,
-                    gateway: options[:gateway]
-                  }
-                  ip_msg = options[:ip] + '/'
-                else
-                  network = {
-                    interface: index,
-                    type: :dhcp,
-                    use_dhcp_assigned_default_route: options[:use_dhcp_assigned_default_route],
-                    guest_mac_address: options[:mac]
-                  }
-                  ip_msg = 'dhcp'
-                  netmask = ''
-                end
-                networks_to_configure << network
-                env[:ui].info I18n.t('vagrant_vmware_esxi.vagrant_vmware_esxi_message',
-                                     message: "Configuring     : #{ip_msg}#{netmask} on #{config.esxi_virtual_network[index]}")
-              end
+          env[:machine].config.vm.networks.each.with_index do |(type, options), index|
+            next if type != :private_network && type != :public_network
+            next if options[:auto_config] === false
+
+            network = {
+              interface: index + 1,
+              use_dhcp_assigned_default_route: options[:use_dhcp_assigned_default_route],
+              guest_mac_address: options[:mac],
+            }
+
+            if options[:ip]
+              network.merge!(
+                type: :static,
+                ip: options[:ip],
+                netmask: options[:netmask],
+                gateway: options[:gateway]
+              )
+              ip_msg = "#{options[:ip]}/#{options[:netmask]}"
+            else
+              network.merge!(type: :dhcp)
+              ip_msg = 'dhcp'
             end
 
-            #
-            #  Save network configuration for provisioner to do changes.
-            #
-            sleep(1)
-            env[:machine].guest.capability(
-                :configure_networks, networks_to_configure)
+            networks_to_configure << network
+            env[:ui].info I18n.t('vagrant_vmware_esxi.vagrant_vmware_esxi_message',
+                                 message: "Configuring     : #{ip_msg} on #{options[:esxi__port_group]}")
           end
+
+          sleep(1)
+          env[:machine].guest.capability(:configure_networks, networks_to_configure)
         end
       end
     end

--- a/lib/vagrant-vmware-esxi/command/destroy_networks.rb
+++ b/lib/vagrant-vmware-esxi/command/destroy_networks.rb
@@ -1,0 +1,38 @@
+require "optparse"
+
+module VagrantPlugins
+  module ESXi
+    module Command
+      class DestroyNetworks < Vagrant.plugin("2", :command)
+        def self.synopsis
+          "destroy VMWare ESXi networks (port groups) and vSwitches that were created automatically"
+        end
+
+        def execute
+          force = false
+
+          opts = OptionParser.new do |o|
+            o.banner = "Usage: vagrant destroy-networks"
+            o.separator ""
+            o.separator "Options:"
+            o.separator ""
+
+            o.on("-f", "--force", "Destroy without confirmation.") do |f|
+              force = f
+            end
+          end
+
+          # Parse the options
+          argv = parse_options(opts)
+          return if !argv
+
+          with_target_vms(nil) do |machine|
+            machine.action(:destroy_networks, scope: :all, force_confirm_destroy_networks: force)
+          end
+
+          0
+        end
+      end
+    end
+  end
+end

--- a/lib/vagrant-vmware-esxi/config.rb
+++ b/lib/vagrant-vmware-esxi/config.rb
@@ -11,6 +11,11 @@ module VagrantPlugins
       attr_accessor :encoded_esxi_password
       attr_accessor :esxi_disk_store
       attr_accessor :esxi_virtual_network
+      attr_accessor :default_vswitch
+      attr_accessor :default_port_group
+      attr_accessor :destroy_unused_port_groups
+      attr_accessor :destroy_unused_vswitches
+      attr_accessor :destroy_unused_networks
       attr_accessor :esxi_resource_pool
       attr_accessor :clone_from_vm
       attr_accessor :guest_username
@@ -69,6 +74,11 @@ module VagrantPlugins
         @encoded_esxi_password = nil
         @esxi_disk_store = nil
         @esxi_virtual_network = nil
+        @default_vswitch = UNSET_VALUE
+        @default_port_group = UNSET_VALUE
+        @destroy_unused_port_groups = UNSET_VALUE
+        @destroy_unused_vswitches = UNSET_VALUE
+        @destroy_unused_networks = UNSET_VALUE
         @esxi_resource_pool = nil
         @clone_from_vm = nil
         @guest_username = 'vagrant'
@@ -379,6 +389,17 @@ module VagrantPlugins
         @esxi_virtual_network = [@esxi_virtual_network] if @esxi_virtual_network.is_a? String
 
         @esxi_virtual_network = ['--NotSet--'] if @esxi_virtual_network.nil?
+
+        @default_vswitch = "vSwitch0" if @default_vswitch == UNSET_VALUE
+        @default_port_group = "VM Network" if @default_port_group == UNSET_VALUE
+
+        @destroy_unused_port_groups = false if @destroy_unused_port_groups == UNSET_VALUE
+        @destroy_unused_vswitches = false if @destroy_unused_vswitches == UNSET_VALUE
+        @destroy_unused_networks = false if @destroy_unused_networks == UNSET_VALUE
+        if @destroy_unused_networks
+          @destroy_unused_port_groups = true
+          @destroy_unused_vswitches = true
+        end
 
         @local_private_keys = [
           '~/.ssh/id_rsa',

--- a/lib/vagrant-vmware-esxi/ext.rb
+++ b/lib/vagrant-vmware-esxi/ext.rb
@@ -1,0 +1,5 @@
+module Ext
+  ruby_version = RUBY_VERSION.to_f
+
+  require "vagrant-vmware-esxi/ext/ip_addr" if ruby_version < 2.5
+end

--- a/lib/vagrant-vmware-esxi/ext/ip_addr.rb
+++ b/lib/vagrant-vmware-esxi/ext/ip_addr.rb
@@ -1,0 +1,19 @@
+class ::IPAddr
+  def prefix
+    case @family
+    when Socket::AF_INET
+      n = IN4MASK ^ @mask_addr
+      i = 32
+    when Socket::AF_INET6
+      n = IN6MASK ^ @mask_addr
+      i = 128
+    else
+      raise AddressFamilyError, "unsupported address family"
+    end
+    while n.positive?
+      n >>= 1
+      i -= 1
+    end
+    i
+  end
+end

--- a/lib/vagrant-vmware-esxi/plugin.rb
+++ b/lib/vagrant-vmware-esxi/plugin.rb
@@ -38,6 +38,11 @@ module VagrantPlugins
         SnapshotInfo
       end
 
+      command('destroy-networks') do
+        require_relative "command/destroy_networks"
+        Command::DestroyNetworks
+      end
+
       # This initializes the internationalization strings.
       def self.setup_i18n
         require 'pathname'
@@ -66,7 +71,7 @@ module VagrantPlugins
         # Set the logging level on all "vagrant" namespaced
         # logs as long as we have a valid level.
         if level
-          logger = Log4r::Logger.new('vagrant_esxi')
+          logger = Log4r::Logger.new('vagrant_vmware_esxi')
           logger.outputters = Log4r::Outputter.stderr
           logger.level = level
           logger = nil

--- a/lib/vagrant-vmware-esxi/util/esxcli.rb
+++ b/lib/vagrant-vmware-esxi/util/esxcli.rb
@@ -1,0 +1,145 @@
+module VagrantPlugins
+  module ESXi
+    module Util
+      module ESXCLI
+        PORT_GROUP_HEADER_RE = /^(?<name>-+)\s+(?<vswitch>-+)\s+(?<clients>-+)\s+(?<vlan>-+)$/
+        PORT_GROUP_NAME_IN_VMSVC_RE = /^\s*name = "(?<name>.+)",\s*$/
+
+        def has_vswitch?(vswitch)
+          r = exec_ssh("esxcli network vswitch standard list | "\
+                       "grep -E '^#{vswitch}$'")
+
+          r.exitstatus == 0
+        end
+
+        def create_vswitch(vswitch)
+          r = exec_ssh("esxcli network vswitch standard add -v '#{vswitch}'")
+
+          r.exitstatus == 0
+        end
+
+        # @return [Hash] Map of port group to :vswitch, :clients (running VMs) and :vlan 
+        def get_port_groups
+          r = exec_ssh("esxcli network vswitch standard portgroup list")
+          if r.exitstatus != 0
+            raise Errors::ESXiError, message: "Unable to get port groups"
+          end
+
+          # Parse output such as:
+          # Name                           Virtual Switch    Active Clients  VLAN ID
+          # -----------------------------  ----------------  --------------  -------
+          # Management Network             vSwitch0                       1        0
+          # Internal                       Internal                       0        0
+
+          lines = r.strip.split("\n")
+          max_name_len, max_vswitch_len, max_clients_len, max_vlan_len =
+            lines[1].match(PORT_GROUP_HEADER_RE).captures.map(&:length)
+
+          lines[2..-1].map do |line|
+            m = line.match(/^
+              (?<name>.{#{max_name_len}})\s+
+              (?<vswitch>.{#{max_vswitch_len}})\s+
+              (?<clients>.{#{max_clients_len}})\s+
+              (?<vlan>.{#{max_vlan_len}})
+            $/x)
+
+            [m[:name].strip, {
+              vswitch: m[:vswitch].strip,
+              clients: m[:clients].to_i,
+              vlan: m[:vlan].to_i
+            }]
+          end.to_h
+        end
+
+        # Port groups that are attached to any VM
+        def get_active_port_group_names
+          r = exec_ssh("vim-cmd vmsvc/getallvms | cut -d' ' -f1 | tail -n +2")
+          if r.exitstatus != 0
+            raise Errors::ESXiError, message: "Unable to get active port groups"
+          end
+
+          port_group_names = []
+
+          r.strip.split("\n").each do |vmid|
+            r = exec_ssh("vim-cmd vmsvc/get.networks #{vmid}")
+            if r.exitstatus != 0
+              raise Errors::ESXiError, message: "Unable to get port groups for vm '#{vmid}'"
+            end
+
+            r.strip.split("\n").each do |line|
+              if matches = PORT_GROUP_NAME_IN_VMSVC_RE.match(line)
+                port_group_name = matches[:name]
+                port_group_names << port_group_name unless port_group_names.include?(port_group_name)
+              end
+            end
+          end
+
+          port_group_names
+        end
+
+        def get_vswitch_port_group_names(vswitch)
+          r = exec_ssh("esxcli network vswitch standard list -v '#{vswitch}' | "\
+                       "grep Portgroups | "\
+                       'sed -E "s/^\s+Portgroups: //"')
+
+          if r.exitstatus != 0
+            raise Errors::ESXiError, message: "Unable to get port groups for vswitch '#{vswitch}'"
+          end
+
+          r.strip.split(", ")
+        end
+
+        def remove_vswitch(vswitch)
+          r  = exec_ssh("esxcli network vswitch standard remove -v '#{vswitch}'")
+
+          r.exitstatus == 0
+        end
+
+        def create_port_group(port_group, vswitch, vlan = 0)
+          # Use vim-cmd instead of esxcli, as it can add port group to vlan in a go
+          r = exec_ssh("vim-cmd hostsvc/net/portgroup_add "\
+                       "'#{vswitch}' "\
+                       "'#{port_group}' "\
+                       "#{vlan}")
+
+          r.exitstatus == 0
+        end
+
+        def remove_port_group(port_group, vswitch)
+          r  = exec_ssh("esxcli network vswitch standard portgroup remove -p '#{port_group}' -v '#{vswitch}'")
+
+          r.exitstatus == 0
+        end
+
+        # Client should probably never use this, add a method in this module instead
+        def exec_ssh(cmd)
+          @_ssh.exec!(cmd).tap do |r|
+            @logger.debug("exec_ssh: `#{cmd}`\n#{r}") if @logger
+          end
+        end
+
+        def connect_ssh
+          if @_ssh
+            raise Errors::ESXiError, message: "SSH session already established"
+          end
+
+          config = @env[:machine].provider_config
+          Net::SSH.start(
+            config.esxi_hostname,
+            config.esxi_username,
+            password: config.esxi_password,
+            port: config.esxi_hostport,
+            keys: config.local_private_keys,
+            timeout: 20,
+            number_of_password_prompts: 0,
+            non_interactive: true
+          ) do |ssh|
+            @_ssh = ssh
+            yield
+            @_ssh = nil
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
I'm not sure whether you will want this and there are some more work to do on this one, but please don't merge this yet. If you are interested, I may be able to make some changes.

Essentially, it adds networks like VirtualBox provider, by using port groups and VLANs.

## Details
This creates port groups (networks) and vSwitches automatically on `vagrant up`. The networks are created like virtualbox provider. It also optionally destroys the networks and the vSwitches on machine destroy.

Helper command `destroy-networks` is added for convenience, to destroy all networks matching a pattern `{vSwitchName}-{network-address}-{network-prefix}`

## Example Vagrantfile
```ruby
Vagrant.configure("2") do |config|
  config.vm.box = "hashicorp/bionic64"

  config.vm.provider :vmware_esxi do |esxi|
    esxi.esxi_hostname = "x.x.x.x"
    esxi.esxi_username = "root"
    esxi.esxi_password = "password"
    esxi.guest_memsize = "512"

    # esxi.destroy_unused_port_groups= true

    # Defaults
    # exsi.default_vswitch = "vSwitch0"
    # exsi.default_port_group = "VM Network"
    # esxi.destroy_unused_port_groups= false
    # esxi.destroy_unused_vswitches = false
    # esxi.destroy_unused_networks = false     # sets to the previous 2 options 
  end

  # creates port group `vSwitch0-192.168.100.0-24` on `vSwitch0`
  config.vm.network "private_network", ip: "192.168.100.2"

  # creates port group `vSwitch0-10.10.10.0-16` on `vSwitch0`
  config.vm.network "private_network", ip: "10.10.10.2", netmask: "16"

  # creates port group `Port Group A` on `vSwitch0`
  config.vm.network "private_network", ip: "172.16.10.20", esxi__port_group: "Port Group A"

  # creates port group `Port Group B` on `vSwitch0`
  config.vm.network "private_network", dhcp: true, esxi__port_group: "Port Group B"

  # should fail, default_port_group not in esxi__vswitch
  # config.vm.network "private_network", ip: "192.168.10.2", esxi__vswitch: "Should Fail 1"

  # creates port group `Port Group C` on `vSwitch 1`
  config.vm.network "private_network", ip: "10.20.20.2", esxi__vswitch: "vSwitch 1", esxi__port_group: "Port Group C"

  # should fail, default_port_group not in esxi__vswitch
  # config.vm.network "private_network", dhcp: true, esxi__vswitch: "Should Fail 2"

  # creates port group `Port Group D` on `vSwitch 2`
  config.vm.network "private_network", dchp: true, esxi__vswitch: "vSwitch 2", esxi__port_group: "Port Group D"

  config.vm.synced_folder('.', '/vagrant', type: 'rsync')
end
```

## Example `vagrant up` and `vagrant destroy`
<details>
  <summary>Click to expand!</summary>

```
ninja@ubuntu2004-1:~/vagrantesxi$ vagrant up --provider vmware_esxi                                                                                                                 
                                                                                                                                                                                        
Bringing machine 'default' up with 'vmware_esxi' provider... 
==> default: --- Default network on Adapter 1: vSwitch: vSwitch0, port group: VM Network                                                                                                
==> default: --- Creating other networks...                                                  
    default: --- Adapter 2: vSwitch: vSwitch0, port group: vSwitch0-192.168.100.0-24         
    default: --- Adapter 3: vSwitch: vSwitch0, port group: vSwitch0-10.10.0.0-16             
    default: --- Adapter 4: vSwitch: vSwitch0, port group: Port Group A                      
    default: --- Adapter 5: vSwitch: vSwitch0, port group: Port Group B                      
    default: --- Adapter 6: vSwitch: vSwitch 1, port group: Port Group C                     
    default: --- Adapter 7: vSwitch: vSwitch 2, port group: Port Group D                     
==> default: Virtual Machine will be built.                                                  
VMware ovftool 4.4.0 (build-16360108)                                                        
==> default: --- WARNING         : esxi_disk_store not set, using "--- Least Used ---"       
==> default: ---   --- ESXi Summary ---                                                                                                                                                 
==> default: --- ESXi host       : x.x.x.x                                  
==> default: --- Virtual Network : ["VM Network", "vSwitch0-192.168.100.0-24", "vSwitch0-10.10.0.0-16", "Port Group A", "Port Group B", "Port Group C", "Port Group D"]                 
==> default: --- Disk Store      : datastore1                                                
==> default: --- Resource Pool   : /                                                         
==> default: ---  --- Guest Summary ---                                                      
==> default: --- VM Name         : V-ubuntu2004-1-ninja-vagrantesxi                          
==> default: --- Box             : hashicorp/bionic64                                        
==> default: --- Box Ver         : 1.0.282                                                   
==> default: --- Memsize (MB)    : 512                                                       
==> default: --- CPUS            : 1                                                         
==> default: --- Guest OS type   : ubuntu-64                                                                                                                                            
==> default: --- Resource Pool   : / 
==> default: ---  --- Guest Summary --- 
==> default: --- VM Name         : V-ubuntu2004-1-ninja-vagrantesxi 
==> default: --- Box             : hashicorp/bionic64 
==> default: --- Box Ver         : 1.0.282 
==> default: --- Memsize (MB)    : 512 
==> default: --- CPUS            : 1 
==> default: --- Guest OS type   : ubuntu-64 
==> default: ---   --- Guest Build --- 
Opening VMX source: /home/ninja/.vagrant.d/boxes/hashicorp-VAGRANTSLASH-bionic64/1.0.282/vmware_desktop/ZZZZ_V-ubuntu2004-1-ninja-vagrantesxi.vmx 
Opening VI target: vi://root@x.x.x.x:443/ 
Deploying to VI: vi://root@x.x.x.x:443/ 
Transfer Completed                     
Completed successfully 
==> default: --- VMID            : 72 
==> default: --- VM has been Powered On... 
==> default: --- Waiting for state "running" 
==> default: --- Success, state is now "running" 
==> default: --- Configuring     : 192.168.100.2/24 on vSwitch0-192.168.100.0-24 
==> default: --- Configuring     : 10.10.10.2/16 on vSwitch0-10.10.0.0-16 
==> default: --- Configuring     : 172.16.10.20/24 on Port Group A 
==> default: --- Configuring     : dhcp on Port Group B 
==> default: --- Configuring     : 10.20.20.2/24 on Port Group C 
==> default: --- Configuring     : dhcp on Port Group D 
    default:  
    default: Vagrant insecure key detected. Vagrant will automatically replace 
    default: this with a newly generated keypair for better security. 
    default:  
    default: Inserting generated public key within guest... 
    default: Removing insecure key from the guest if it's present... 
    default: Key inserted! Disconnecting and reconnecting using new SSH key... 
==> default: Rsyncing folder: /home/ninja/vagrantesxi/ => /vagrant 
ninja@ubuntu2004-1:~/vagrantesxi$ vagrant destroy 
 
==> default: powered off 
==> default: --- VM has been destroyed... 
==> default: --- Destroying unused port groups that were created automatically... 
    default: --- Destroying port group 'vSwitch0-192.168.100.0-24' 
    default: --- Destroying port group 'vSwitch0-10.10.0.0-16' 
    default: --- Destroying port group 'Port Group A' 
    default: --- Destroying port group 'Port Group B' 
    default: --- Destroying port group 'Port Group C' 
    default: --- Destroying port group 'Port Group D' 
==> default: --- Destroying unused vSwitches that were created automatically... 
    default: --- Destroying vswitch 'vSwitch 1' 
    default: --- Destroying vswitch 'vSwitch 2' 
ninja@ubuntu2004-1:~/vagrantesxi$  
```
</details>