### PR TITLE
Exclude 127.* addresses from primary selection method

### DIFF
--- a/lib/vagrant-vmware-esxi/action/read_state.rb
+++ b/lib/vagrant-vmware-esxi/action/read_state.rb
@@ -29,7 +29,11 @@ module VagrantPlugins
               begin
                 puts "Get local IP address for NFS. (pri)" if env[:machine].provider_config.debug =~ %r{ip}i
                 #  The Standard way to get your IP.  Get your hostname, resolv it.
-                env[:nfs_host_ip] = Socket::getaddrinfo(Socket.gethostname,"echo",Socket::AF_INET)[0][3]
+                addr_info = Socket::getaddrinfo(Socket.gethostname,"echo",Socket::AF_INET)
+
+                non_localhost = addr_info.select{ |info| info[3] !~ /^127./}
+
+                env[:nfs_host_ip] = non_localhost[0][3]
               rescue
                 puts "Get local IP address for NFS. (alt)" if env[:machine].provider_config.debug =~ %r{ip}i
                 #  Alt method.  Get list of ip_addresses on system and use the first.


### PR DESCRIPTION
In my multi-homed macOS system (10.15.6 (19G2021)), I was finding that localhost addresses were still being captured as part of the `nfs_host_ip`. This obviously was not working.

This is the data I was getting from the Socket calls:

```ruby
> Socket::getaddrinfo(Socket.gethostname,"echo",Socket::AF_INET)
=> [["AF_INET", 4, "127.0.0.1", "127.0.0.1", 2, 2, 17], ["AF_INET", 4, "127.0.0.1", "127.0.0.1", 2, 1, 6], ["AF_INET", 4, "192.168.42.22", "192.168.42.22", 2, 2, 17], ["AF_INET", 4, "192.168.42.22", "192.168.42.22", 2, 1, 6]]
```

This is just a quick change to exclude the `127.*` addresses from the primary IP address selection.