### PR TITLE
Fix packaging in Windows10

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,23 @@
+# Ignore bundler config
+/.bundle
+
+# Ignore the default SQLite database.
+/db/*.sqlite3
+
+# Ignore all logfiles and tempfiles.
+/log/*.log
+/tmp
+
+*.gem
+*.rbc
+.bundle
+.config
+coverage
+InstalledFiles
+lib/bundler/man
+pkg
+rdoc
+spec/reports
+test/tmp
+test/version_tmp
+tmp

--- a/lib/vagrant-vmware-esxi/action/package.rb
+++ b/lib/vagrant-vmware-esxi/action/package.rb
@@ -56,11 +56,15 @@ module VagrantPlugins
                              "  local_allow_overwrite='True' in Vagrantfile for force."
             end
 
+            is_mingw = Gem::Platform.local.os == "mingw32"
+
             # Find a tar/bsdtar
             if system 'tar --version >/dev/null 2>&1'
               tar_cmd = 'tar'
             elsif system 'bsdtar --version >/dev/null 2>&1'
               tar_cmd = 'bsdtar'
+            elsif is_mingw && system('tar --version > nul 2>&1')
+              tar_cmd = 'tar'  
             else
               raise Errors::ESXiConfigError,
                     message: 'unable to find tar in your path.'
@@ -120,7 +124,8 @@ module VagrantPlugins
             end
 
             env[:ui].info("tarring #{boxname}.box")
-            unless system "cd #{tmpdir}/#{boxname} ; #{tar_cmd} cvf ../../#{boxname}.box *"
+            combinator_string = is_mingw ? "&&" : ";"
+            unless system "cd #{tmpdir}/#{boxname} #{combinator_string} #{tar_cmd} cvf ../../#{boxname}.box *"
               raise Errors::GeneralError,
                     message: 'tar command failed.'
             end


### PR DESCRIPTION
- Unable to detect tar (redirect was made in linux style only)
- Command concatenation was not compatible with cmd (Windows)

Tested on my Windows 10 updated up to 20H2.
Now I'm able to perform a `vagrant package` command