### PR TITLE
esxi: updated guestos types and virtualhw to 8.0.2

### DIFF
--- a/ESXi_guestos_types.md
+++ b/ESXi_guestos_types.md
@@ -18,7 +18,7 @@ Darwin (mac):
 'darwin10-64','darwin10','darwin11-64','darwin11','darwin12-64','darwin13-64','darwin14-64','darwin15-64','darwin16-64','darwin-64','darwin'
 
 Debian:
-'debian10-64','debian10','debian4-64','debian4','debian5-64','debian5','debian6-64','debian6','debian7-64','debian7','debian8-64','debian8','debian9-64','debian9'
+'debian12-64','debian12','debian11-64','debian11','debian10-64','debian10','debian4-64','debian4','debian5-64','debian5','debian6-64','debian6','debian7-64','debian7','debian8-64','debian8','debian9-64','debian9'
 
 Dos & Other:
 'dos','os2','oes','other','sjds','coreos-64'

--- a/lib/vagrant-vmware-esxi/config.rb
+++ b/lib/vagrant-vmware-esxi/config.rb
@@ -94,7 +94,7 @@ module VagrantPlugins
         @debug = 'False'
         @saved_ipaddress = nil
         @supported_guest_virtualhw_versions = [
-          4,7,8,9,10,11,12,13,14,15,16,17,18,19
+          4,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21
         ]
         @supported_guest_disk_types = [
           'thin',
@@ -143,6 +143,8 @@ module VagrantPlugins
           'debian10',
           'debian11-64',
           'debian11',
+          'debian12-64',
+          'debian12',
           'debian4-64',
           'debian4',
           'debian5-64',


### PR DESCRIPTION
New `guest_guestos` types:

- `debian12-64`: Debian 12 (aka Bookworm) 64-bit
- `debian12`: Debian 12 (aka Bookworm) 32-bit

New `guest_virtualhw_version` value:

`20`: For ESXi 8.0
`21`: for ESXi 8.0 U (8.0.2)