### PR TITLE
Add centralized SSH connection pool and Windows network support

### DIFF
--- a/lib/vagrant-vmware-esxi/action/destroy.rb
+++ b/lib/vagrant-vmware-esxi/action/destroy.rb
@@ -1,5 +1,5 @@
 require 'log4r'
-require 'net/ssh'
+require_relative 'esxi_connection'
 
 module VagrantPlugins
   module ESXi
@@ -33,24 +33,14 @@ module VagrantPlugins
             raise Errors::ESXiError,
                   message: 'Guest VM should have been powered off...'
           else
-            Net::SSH.start(config.esxi_hostname, config.esxi_username,
-              password:                   config.esxi_password,
-              port:                       config.esxi_hostport,
-              keys:                       config.local_private_keys,
-              timeout:                    20,
-              number_of_password_prompts: 0,
-              non_interactive:            true
-            ) do |ssh|
-
-              r = ssh.exec!("vim-cmd vmsvc/destroy #{machine.id}")
-              if r.exitstatus != 0
-                raise Errors::ESXiError,
-                      message: "Unable to destroy the VM:\n"\
-                                 "  #{r}"
-              end
-              env[:ui].info I18n.t('vagrant_vmware_esxi.vagrant_vmware_esxi_message',
-                                   message: 'VM has been destroyed...')
+            r = ESXiConnection.exec!(env, "vim-cmd vmsvc/destroy #{machine.id}")
+            if r.exitstatus != 0
+              raise Errors::ESXiError,
+                    message: "Unable to destroy the VM:\n"\
+                               "  #{r}"
             end
+            env[:ui].info I18n.t('vagrant_vmware_esxi.vagrant_vmware_esxi_message',
+                                 message: 'VM has been destroyed...')
           end
         end
       end

--- a/lib/vagrant-vmware-esxi/action/esxi_connection.rb
+++ b/lib/vagrant-vmware-esxi/action/esxi_connection.rb
@@ -1,0 +1,192 @@
+require 'net/ssh'
+require 'log4r'
+
+module VagrantPlugins
+  module ESXi
+    module Action
+      # Helper module for managing SSH connections to ESXi hosts.
+      #
+      # Design goals:
+      # - Support parallel VM operations (each machine gets its own connection)
+      # - Automatic reconnection on stale/dead connections
+      # - Thread-safe connection management
+      #
+      # Usage:
+      #   # Preferred - uses automatic reconnection on failure:
+      #   result = ESXiConnection.exec!(env, "vim-cmd vmsvc/getallvms")
+      #
+      #   # For multiple commands in sequence, get a session:
+      #   ESXiConnection.with_session(env) do |ssh|
+      #     ssh.exec!("command1")
+      #     ssh.exec!("command2")
+      #   end
+      module ESXiConnection
+        # Connection pool keyed by "host:port" - shared across all VMs on same host
+        # This mimics OpenSSH ControlMaster behavior
+        @@connections = {}
+        @@mutex = Mutex.new
+        @@at_exit_registered = false
+        @@logger = Log4r::Logger.new('vagrant_vmware_esxi::action::esxi_connection')
+
+        # Register at_exit hook to close all connections when Ruby exits
+        def self.register_at_exit
+          return if @@at_exit_registered
+          @@at_exit_registered = true
+          at_exit do
+            close_all_connections
+          end
+        end
+
+        # Build connection key - shared per ESXi host
+        def self.connection_key(env)
+          config = env[:machine].provider_config
+          "#{config.esxi_hostname}:#{config.esxi_hostport}"
+        end
+
+        # Create a new SSH connection to ESXi host
+        def self.create_connection(env)
+          config = env[:machine].provider_config
+          key = connection_key(env)
+
+          @@logger.debug("Opening SSH connection to #{key}")
+
+          max_retries = 3
+          retry_count = 0
+
+          begin
+            ssh = Net::SSH.start(config.esxi_hostname, config.esxi_username,
+              password:                   config.esxi_password,
+              port:                       config.esxi_hostport,
+              keys:                       config.local_private_keys,
+              timeout:                    30,
+              number_of_password_prompts: 0,
+              non_interactive:            true,
+              keepalive:                  true,
+              keepalive_interval:         30
+            )
+
+            @@mutex.synchronize do
+              # Close any existing connection for this key
+              if @@connections[key] && !@@connections[key].closed?
+                begin
+                  @@connections[key].close
+                rescue
+                  # Ignore errors when closing old connection
+                end
+              end
+              @@connections[key] = ssh
+            end
+
+            register_at_exit
+            @@logger.debug("SSH connection established for #{key}")
+            ssh
+          rescue Net::SSH::Exception, Errno::ECONNRESET, Errno::ECONNREFUSED, Errno::ETIMEDOUT, IOError => e
+            retry_count += 1
+            if retry_count <= max_retries
+              @@logger.debug("Connection failed: #{e.message}. Retrying in #{retry_count * 2}s...")
+              sleep(retry_count * 2)
+              retry
+            else
+              raise
+            end
+          end
+        end
+
+        # Get an SSH connection, creating new or reusing existing if healthy
+        def self.get_connection(env)
+          key = connection_key(env)
+
+          @@mutex.synchronize do
+            existing = @@connections[key]
+            if existing && !existing.closed?
+              return existing
+            end
+          end
+
+          # Create new connection outside mutex to avoid blocking
+          create_connection(env)
+        end
+
+        # Execute a command with automatic reconnection on failure.
+        # This is the preferred method for running commands.
+        def self.exec!(env, command)
+          max_retries = 2
+          retry_count = 0
+
+          begin
+            ssh = get_connection(env)
+            ssh.exec!(command)
+          rescue Net::SSH::Exception, Errno::ECONNRESET, Errno::EPIPE, IOError => e
+            retry_count += 1
+            if retry_count <= max_retries
+              @@logger.debug("Command failed: #{e.message}. Reconnecting...")
+              close_connection(env)
+              sleep(1)
+              retry
+            else
+              raise
+            end
+          end
+        end
+
+        # Execute multiple commands within a session block with automatic reconnection.
+        # Use this when you need direct SSH access (e.g., for open_channel).
+        def self.with_session(env, &block)
+          max_retries = 2
+          retry_count = 0
+
+          begin
+            ssh = get_connection(env)
+            yield ssh
+          rescue Net::SSH::Exception, Errno::ECONNRESET, Errno::EPIPE, IOError => e
+            retry_count += 1
+            if retry_count <= max_retries
+              @@logger.debug("Session failed: #{e.message}. Reconnecting...")
+              close_connection(env)
+              sleep(1)
+              retry
+            else
+              raise
+            end
+          end
+        end
+
+        # Close the SSH connection for a specific machine.
+        # The next get_connection or exec! call will create a fresh connection.
+        def self.close_connection(env)
+          key = connection_key(env)
+
+          @@mutex.synchronize do
+            if @@connections[key]
+              begin
+                @@connections[key].close unless @@connections[key].closed?
+              rescue
+                # Ignore errors when closing
+              end
+              @@connections.delete(key)
+              @@logger.debug("Connection closed for #{key}")
+            end
+          end
+        end
+
+        # Close all connections (for cleanup)
+        def self.close_all_connections
+          @@mutex.synchronize do
+            @@connections.each do |key, ssh|
+              begin
+                unless ssh.closed?
+                  @@logger.debug("Closing SSH connection for #{key}")
+                  ssh.close
+                end
+              rescue => e
+                # Ignore errors when closing
+                @@logger.debug("Error closing #{key}: #{e.message}")
+              end
+            end
+            @@connections.clear
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/vagrant-vmware-esxi/action/halt.rb
+++ b/lib/vagrant-vmware-esxi/action/halt.rb
@@ -1,5 +1,5 @@
 require 'log4r'
-require 'net/ssh'
+require_relative 'esxi_connection'
 
 module VagrantPlugins
   module ESXi
@@ -28,24 +28,14 @@ module VagrantPlugins
           elsif env[:machine_state].to_s == 'not_created'
             env[:ui].info I18n.t('vagrant_vmware_esxi.already_destroyed')
           else
-            Net::SSH.start(config.esxi_hostname, config.esxi_username,
-              password:                   config.esxi_password,
-              port:                       config.esxi_hostport,
-              keys:                       config.local_private_keys,
-              timeout:                    20,
-              number_of_password_prompts: 0,
-              non_interactive:            true
-            ) do |ssh|
+            r = ESXiConnection.exec!(env, "vim-cmd vmsvc/power.off #{machine.id}")
+            config.saved_ipaddress = nil
 
-              r = ssh.exec!("vim-cmd vmsvc/power.off #{machine.id}")
-              config.saved_ipaddress = nil
-
-              if r.exitstatus != 0
-                raise Errors::ESXiError,
-                      message: "Unable to power off the VM:\n    #{r}"
-              end
-              env[:ui].info I18n.t('vagrant_vmware_esxi.states.powered_off.short')
+            if r.exitstatus != 0
+              raise Errors::ESXiError,
+                    message: "Unable to power off the VM:\n    #{r}"
             end
+            env[:ui].info I18n.t('vagrant_vmware_esxi.states.powered_off.short')
           end
         end
       end

--- a/lib/vagrant-vmware-esxi/action/read_ssh_info.rb
+++ b/lib/vagrant-vmware-esxi/action/read_ssh_info.rb
@@ -1,5 +1,5 @@
 require 'log4r'
-require 'net/ssh'
+require_relative 'esxi_connection'
 
 module VagrantPlugins
   module ESXi
@@ -40,55 +40,48 @@ module VagrantPlugins
 
           if config.saved_ipaddress.nil? or config.local_use_ip_cache == 'False'
 
-            #  Figure out vm_ipaddress
-            Net::SSH.start(config.esxi_hostname, config.esxi_username,
-              password:                   config.esxi_password,
-              port:                       config.esxi_hostport,
-              keys:                       config.local_private_keys,
-              timeout:                    20,
-              number_of_password_prompts: 0,
-              non_interactive:            true
-            ) do |ssh|
+            @logger = Log4r::Logger.new('vagrant_vmware_esxi::action::'\
+                                        'read_ssh_info-net_ssh')
 
-              @logger = Log4r::Logger.new('vagrant_vmware_esxi::action::'\
-                                          'read_ssh_info-net_ssh')
+            #  ugly, but it works...
+            #    Try to get first interface.  This is the prefered method
+            #    when you have multiple network interfaces
+            ssh_execute_cmd = "vim-cmd vmsvc/get.guest #{machine.id} 2>/dev/null |"
+            ssh_execute_cmd << 'sed \'1!G;h;$!d\' |awk \'/deviceConfigId = 4000/,/ipAddress/\' |'
+            ssh_execute_cmd << 'grep -oE "((1?[0-9][0-9]?|2[0-4][0-9]|25[0-5])\\.){3}(1?[0-9][0-9]?|2[0-4][0-9]|25[0-5])" |tail -1'
+            r = ESXiConnection.exec!(env, ssh_execute_cmd)
+            ipaddress = r.strip
+            @logger.debug("read_ssh_info: IP detection method 1 result: '#{ipaddress}'")
 
-              #  ugly, but it works...
-              #    Try to get first interface.  This is the prefered method
-              #    when you have multiple network interfaces
-              ssh_execute_cmd = "vim-cmd vmsvc/get.guest #{machine.id} 2>/dev/null |"
-              ssh_execute_cmd << 'sed \'1!G;h;$!d\' |awk \'/deviceConfigId = 4000/,/ipAddress/\' |'
-              ssh_execute_cmd << 'grep -oE "((1?[0-9][0-9]?|2[0-4][0-9]|25[0-5])\\.){3}(1?[0-9][0-9]?|2[0-4][0-9]|25[0-5])" |tail -1'
-              r = ssh.exec!(ssh_execute_cmd)
-              ipaddress = r.strip
-
-              #  Some OS's don't like above method, so use IP from summary (after 120 seconds uptime)
-              r2 = ''
-              if r.length == 0
-                ssh_execute_cmd = "vim-cmd vmsvc/get.summary #{machine.id} 2>/dev/null |"
-                ssh_execute_cmd << 'grep "uptimeSeconds ="|sed "s/^.*= //g"|sed s/,//g'
-                uptime = ssh.exec!(ssh_execute_cmd)
-                if uptime.to_i > 120
-                  puts "Get IP alt method, uptime: #{uptime.to_i}" if config.debug =~ %r{ip}i
-                  ssh_execute_cmd = "vim-cmd vmsvc/get.guest #{machine.id} 2>/dev/null |"
-                  ssh_execute_cmd << 'grep "^   ipAddress = "|head -1|'
-                  ssh_execute_cmd << 'grep -oE "((1?[0-9][0-9]?|2[0-4][0-9]|25[0-5])\.){3}(1?[0-9][0-9]?|2[0-4][0-9]|25[0-5])"'
-                  r2 = ssh.exec!(ssh_execute_cmd)
-                  ipaddress = r2.strip
-                end
+            #  Some OS's don't like above method, so use IP from summary (after 120 seconds uptime)
+            r2 = ''
+            if r.length == 0
+              ssh_execute_cmd = "vim-cmd vmsvc/get.summary #{machine.id} 2>/dev/null |"
+              ssh_execute_cmd << 'grep "uptimeSeconds ="|sed "s/^.*= //g"|sed s/,//g'
+              uptime = ESXiConnection.exec!(env, ssh_execute_cmd)
+              if uptime.to_i > 120
+                puts "Get IP alt method, uptime: #{uptime.to_i}" if config.debug =~ %r{ip}i
+                ssh_execute_cmd = "vim-cmd vmsvc/get.guest #{machine.id} 2>/dev/null |"
+                ssh_execute_cmd << 'grep "^   ipAddress = "|head -1|'
+                ssh_execute_cmd << 'grep -oE "((1?[0-9][0-9]?|2[0-4][0-9]|25[0-5])\.){3}(1?[0-9][0-9]?|2[0-4][0-9]|25[0-5])"'
+                r2 = ESXiConnection.exec!(env, ssh_execute_cmd)
+                ipaddress = r2.strip
+                @logger.debug("DEBUG read_ssh_info: IP detection method 2 result: '#{ipaddress}'")
               end
-
-              puts "ip1 (pri):#{r.strip} ip2 (alt):#{r2.strip}" if config.debug =~ %r{ip}i
-
-              return nil if (ipaddress == '')
-
-              config.saved_ipaddress = ipaddress
-
-              return {
-                host: ipaddress,
-                port: 22
-              }
+            else
+              @logger.debug("DEBUG read_ssh_info: Uptime #{uptime.to_i}s < 120s, skipping alt method")
             end
+
+            puts "ip1 (pri):#{r.strip} ip2 (alt):#{r2.strip}" if config.debug =~ %r{ip}i
+
+            return nil if (ipaddress == '')
+
+            config.saved_ipaddress = ipaddress
+
+            return {
+              host: ipaddress,
+              port: 22
+            }
           else
             puts "Using cached guest IP address" if config.debug =~ %r{ip}i
             ipaddress = config.saved_ipaddress

--- a/lib/vagrant-vmware-esxi/action/resume.rb
+++ b/lib/vagrant-vmware-esxi/action/resume.rb
@@ -1,5 +1,5 @@
 require 'log4r'
-require 'net/ssh'
+require_relative 'esxi_connection'
 
 module VagrantPlugins
   module ESXi
@@ -37,29 +37,16 @@ module VagrantPlugins
             env[:ui].info I18n.t('vagrant_vmware_esxi.vagrant_vmware_esxi_message',
                                  message: 'Attempting to resume')
 
-            #
-            Net::SSH.start(config.esxi_hostname, config.esxi_username,
-              password:                   config.esxi_password,
-              port:                       config.esxi_hostport,
-              keys:                       config.local_private_keys,
-              timeout:                    20,
-              number_of_password_prompts: 0,
-              non_interactive:            true,
-              keepalive:                  true,
-              keepalive_interval:         30
-            ) do |ssh|
+            r = ESXiConnection.exec!(env, "vim-cmd vmsvc/power.on #{machine.id}")
+            config.saved_ipaddress = nil
 
-              r = ssh.exec!("vim-cmd vmsvc/power.on #{machine.id}")
-              config.saved_ipaddress = nil
-
-              if r.exitstatus != 0
-                raise Errors::ESXiError,
-                      message: "Unable to resume the VM:\n"\
-                               "  #{r}"
-              end
-              env[:ui].info I18n.t('vagrant_vmware_esxi.vagrant_vmware_esxi_message',
-                                   message: 'VM has been resumed...')
+            if r.exitstatus != 0
+              raise Errors::ESXiError,
+                    message: "Unable to resume the VM:\n"\
+                             "  #{r}"
             end
+            env[:ui].info I18n.t('vagrant_vmware_esxi.vagrant_vmware_esxi_message',
+                                 message: 'VM has been resumed...')
           else
             raise Errors::ESXiError, message: 'Unknown state to resume...'
           end

--- a/lib/vagrant-vmware-esxi/action/set_network_ip.rb
+++ b/lib/vagrant-vmware-esxi/action/set_network_ip.rb
@@ -1,6 +1,8 @@
 require 'log4r'
+require 'base64'
 require 'vagrant/util/network_ip'
 require "vagrant/util/scoped_hash_override"
+require_relative 'esxi_connection'
 
 module VagrantPlugins
   module ESXi
@@ -49,7 +51,6 @@ module VagrantPlugins
             next if vm_network.count >= number_of_adapters
             vm_network << options
           end
-
 
           if (config.debug =~ %r{true}i)
             puts "num adapters: #{number_of_adapters},  vm.network.count: #{vm_network.count}"
@@ -103,18 +104,262 @@ module VagrantPlugins
                   netmask = ''
                 end
                 networks_to_configure << network
+                @logger.debug("networks_to_configure: #{networks_to_configure.inspect}")
                 env[:ui].info I18n.t('vagrant_vmware_esxi.vagrant_vmware_esxi_message',
                                      message: "Configuring     : #{ip_msg}#{netmask} on #{config.esxi_virtual_network[index]}")
               end
             end
 
             #
-            #  Save network configuration for provisioner to do changes.
+            #  Configure networks based on guest OS type
             #
             sleep(1)
-            env[:machine].guest.capability(
-                :configure_networks, networks_to_configure)
+            if windows_guest?(env)
+              configure_windows_networks(env, networks_to_configure)
+            else
+              # Disable cloud-init network configuration if present
+              disable_cloud_init_network(env)
+              env[:machine].guest.capability(
+                  :configure_networks, networks_to_configure)
+            end
           end
+        end
+
+        private
+
+        # Disable cloud-init network configuration if cloud-init is present
+        # This prevents cloud-init from overriding Vagrant's network settings on reboot
+        def disable_cloud_init_network(env)
+          machine = env[:machine]
+
+          # Check if cloud-init is installed
+          unless machine.communicate.test("command -v cloud-init >/dev/null 2>&1")
+            @logger.debug("cloud-init not detected, skipping")
+            return
+          end
+
+          @logger.info("cloud-init detected, disabling network configuration")
+
+          # Create config to disable cloud-init network management
+          # This file tells cloud-init to not touch network configuration
+          config_path = "/etc/cloud/cloud.cfg.d/99-disable-network-config.cfg"
+
+          begin
+            # Check if already disabled
+            if machine.communicate.test("test -f #{config_path}")
+              @logger.debug("cloud-init network already disabled")
+            else
+              # Write the disable config using a here-doc to avoid quoting issues
+              machine.communicate.sudo("mkdir -p /etc/cloud/cloud.cfg.d")
+              machine.communicate.sudo("cat > #{config_path} << 'EOF'\nnetwork: {config: disabled}\nEOF")
+
+              env[:ui].info I18n.t('vagrant_vmware_esxi.vagrant_vmware_esxi_message',
+                                   message: "Disabled cloud-init network config")
+            end
+
+            # Always remove cloud-init's netplan config if it exists (it may conflict)
+            if machine.communicate.test("test -f /etc/netplan/50-cloud-init.yaml")
+              machine.communicate.sudo("rm -f /etc/netplan/50-cloud-init.yaml")
+              # Re-apply netplan after removing cloud-init config
+              machine.communicate.sudo("netplan apply 2>/dev/null || true")
+              env[:ui].info I18n.t('vagrant_vmware_esxi.vagrant_vmware_esxi_message',
+                                   message: "Removed cloud-init netplan config")
+            end
+          rescue => e
+            @logger.warn("Failed to disable cloud-init network: #{e.message}")
+            env[:ui].info I18n.t('vagrant_vmware_esxi.vagrant_vmware_esxi_message',
+                                 message: "WARNING         : Failed to disable cloud-init: #{e.message}")
+          end
+        end
+
+        # Detect if the guest is a Windows machine
+        def windows_guest?(env)
+          # Check using Vagrant's guest detection
+          begin
+            guest_name = env[:machine].guest.name.to_s.downcase
+            return true if guest_name.include?('windows')
+          rescue
+            # Guest detection might fail, fall through to other methods
+          end
+
+          # Check the configured guest OS type
+          config = env[:machine].provider_config
+          if config.guest_guestos
+            guestos = config.guest_guestos.to_s.downcase
+            return true if guestos.start_with?('win') || guestos.include?('windows')
+          end
+
+          false
+        end
+
+        # Get MAC addresses for network adapters from ESXi
+        def get_adapter_mac_addresses(env)
+          machine = env[:machine]
+          mac_addresses = {}
+
+          # Query VMware for guest NIC info - extract all MAC addresses
+          # The NICs are listed in order (ethernet0, ethernet1, etc.)
+          cmd = "vim-cmd vmsvc/get.guest #{machine.id} 2>/dev/null | " \
+                "grep 'macAddress = ' | grep -oE '\"[0-9a-fA-F:]+\"'"
+          result = ESXiConnection.exec!(env, cmd)
+
+          adapter_index = 0
+          result.to_s.each_line do |line|
+            if line =~ /"([0-9a-fA-F:]+)"/
+              mac = $1.downcase
+              mac_addresses[adapter_index] = mac
+              @logger.debug("Found MAC for adapter #{adapter_index}: #{mac}")
+              adapter_index += 1
+            end
+          end
+
+          @logger.debug("Detected MAC addresses: #{mac_addresses.inspect}")
+          mac_addresses
+        end
+
+        # Configure network adapters on Windows guests using PowerShell
+        # Workaround for https://github.com/hashicorp/vagrant/issues/12742
+        def configure_windows_networks(env, networks)
+          machine = env[:machine]
+          config = env[:machine].provider_config
+
+          # Get MAC addresses from ESXi
+          mac_addresses = get_adapter_mac_addresses(env)
+
+          # Wait for WinRM/SSH to be ready
+          env[:ui].info I18n.t('vagrant_vmware_esxi.vagrant_vmware_esxi_message',
+                               message: "Configuring Windows network adapters...")
+
+          networks.each do |network|
+            adapter_index = network[:interface]
+            mac = mac_addresses[adapter_index]
+
+            unless mac
+              @logger.warn("Could not find MAC address for adapter #{adapter_index}")
+              env[:ui].info I18n.t('vagrant_vmware_esxi.vagrant_vmware_esxi_message',
+                                   message: "WARNING         : Could not find MAC for adapter #{adapter_index}")
+              next
+            end
+
+            # Format MAC for PowerShell (Windows uses dashes)
+            mac_for_ps = mac.gsub(':', '-').upcase
+
+            if network[:type] == :static
+              configure_windows_static_ip(env, mac_for_ps, network)
+            else
+              configure_windows_dhcp(env, mac_for_ps, adapter_index)
+            end
+          end
+        end
+
+        # Configure a static IP on a Windows adapter identified by MAC address
+        def configure_windows_static_ip(env, mac, network)
+          machine = env[:machine]
+          ip = network[:ip]
+          netmask = network[:netmask]
+          gateway = network[:gateway]
+
+          # Convert netmask to prefix length (e.g., 255.255.255.0 -> 24)
+          prefix_length = netmask_to_prefix(netmask)
+
+          # PowerShell script to configure the adapter
+          # Find adapter by MAC, remove existing IP config, set new static IP
+          ps_script = <<~PS
+            $ErrorActionPreference = 'Stop'
+            $mac = '#{mac}'
+            $adapter = Get-NetAdapter | Where-Object { $_.MacAddress -eq $mac }
+            if (-not $adapter) {
+                Write-Error "Adapter with MAC $mac not found"
+                exit 1
+            }
+            $ifIndex = $adapter.InterfaceIndex
+
+            # Remove existing IP addresses on this adapter
+            Get-NetIPAddress -InterfaceIndex $ifIndex -AddressFamily IPv4 -ErrorAction SilentlyContinue | Remove-NetIPAddress -Confirm:$false -ErrorAction SilentlyContinue
+
+            # Remove existing default gateway if any
+            Get-NetRoute -InterfaceIndex $ifIndex -DestinationPrefix '0.0.0.0/0' -ErrorAction SilentlyContinue | Remove-NetRoute -Confirm:$false -ErrorAction SilentlyContinue
+
+            # Set the new static IP
+            New-NetIPAddress -InterfaceIndex $ifIndex -IPAddress '#{ip}' -PrefixLength #{prefix_length} -ErrorAction Stop
+          PS
+
+          # Add gateway if specified
+          if gateway && !gateway.empty?
+            ps_script += <<~PS
+
+              # Set default gateway
+              New-NetRoute -InterfaceIndex $ifIndex -DestinationPrefix '0.0.0.0/0' -NextHop '#{gateway}' -ErrorAction SilentlyContinue
+            PS
+          end
+
+          ps_script += <<~PS
+
+            Write-Host "Configured adapter $($adapter.Name) with IP #{ip}/#{prefix_length}"
+          PS
+
+          @logger.debug("Configuring Windows static IP: #{ip}/#{prefix_length} on MAC #{mac}")
+
+          begin
+            execute_powershell(machine, ps_script)
+            env[:ui].info I18n.t('vagrant_vmware_esxi.vagrant_vmware_esxi_message',
+                                 message: "Configured      : #{ip}/#{prefix_length} on adapter #{mac}")
+          rescue => e
+            @logger.error("Failed to configure Windows network: #{e.message}")
+            env[:ui].info I18n.t('vagrant_vmware_esxi.vagrant_vmware_esxi_message',
+                                 message: "WARNING         : Failed to configure #{ip} - #{e.message}")
+          end
+        end
+
+        # Configure DHCP on a Windows adapter identified by MAC address
+        def configure_windows_dhcp(env, mac, adapter_index)
+          machine = env[:machine]
+
+          ps_script = <<~PS
+            $ErrorActionPreference = 'Stop'
+            $mac = '#{mac}'
+            $adapter = Get-NetAdapter | Where-Object { $_.MacAddress -eq $mac }
+            if (-not $adapter) {
+                Write-Error "Adapter with MAC $mac not found"
+                exit 1
+            }
+
+            # Enable DHCP
+            Set-NetIPInterface -InterfaceIndex $adapter.InterfaceIndex -Dhcp Enabled -ErrorAction SilentlyContinue
+
+            # Remove any static IPs
+            Get-NetIPAddress -InterfaceIndex $adapter.InterfaceIndex -AddressFamily IPv4 -ErrorAction SilentlyContinue |
+                Where-Object { $_.PrefixOrigin -eq 'Manual' } |
+                Remove-NetIPAddress -Confirm:$false -ErrorAction SilentlyContinue
+
+            Write-Host "Enabled DHCP on adapter $($adapter.Name)"
+          PS
+
+          @logger.debug("Configuring Windows DHCP on MAC #{mac}")
+
+          begin
+            execute_powershell(machine, ps_script)
+            env[:ui].info I18n.t('vagrant_vmware_esxi.vagrant_vmware_esxi_message',
+                                 message: "Configured      : DHCP on adapter #{mac}")
+          rescue => e
+            @logger.error("Failed to configure Windows DHCP: #{e.message}")
+            env[:ui].info I18n.t('vagrant_vmware_esxi.vagrant_vmware_esxi_message',
+                                 message: "WARNING         : Failed to configure DHCP - #{e.message}")
+          end
+        end
+
+        # Execute a PowerShell script on Windows using Base64 encoding to avoid escaping issues
+        def execute_powershell(machine, script)
+          # Encode script as Base64 UTF-16LE for PowerShell's -EncodedCommand
+          encoded = Base64.strict_encode64(script.encode('UTF-16LE'))
+          machine.communicate.execute("powershell -ExecutionPolicy Bypass -EncodedCommand #{encoded}")
+        end
+
+        # Convert netmask to CIDR prefix length
+        def netmask_to_prefix(netmask)
+          octets = netmask.split('.').map(&:to_i)
+          binary = octets.map { |o| o.to_s(2).rjust(8, '0') }.join
+          binary.count('1')
         end
       end
     end

--- a/lib/vagrant-vmware-esxi/action/shutdown.rb
+++ b/lib/vagrant-vmware-esxi/action/shutdown.rb
@@ -1,5 +1,5 @@
 require 'log4r'
-require 'net/ssh'
+require_relative 'esxi_connection'
 
 module VagrantPlugins
   module ESXi
@@ -30,22 +30,12 @@ module VagrantPlugins
           else
             env[:ui].info I18n.t('vagrant_vmware_esxi.vagrant_vmware_esxi_message',
                                  message: "Starting graceful shutdown...")
-            Net::SSH.start(config.esxi_hostname, config.esxi_username,
-              password:                   config.esxi_password,
-              port:                       config.esxi_hostport,
-              keys:                       config.local_private_keys,
-              timeout:                    20,
-              number_of_password_prompts: 0,
-              non_interactive:            true
-            ) do |ssh|
+            r = ESXiConnection.exec!(env, "vim-cmd vmsvc/power.shutdown #{machine.id}")
+            config.saved_ipaddress = nil
 
-              r = ssh.exec!("vim-cmd vmsvc/power.shutdown #{machine.id}")
-              config.saved_ipaddress = nil
-
-              if r.exitstatus != 0
-                raise Errors::ESXiError,
-                      message: "Unable to shutdown the VM:\n    #{r}"
-              end
+            if r.exitstatus != 0
+              raise Errors::ESXiError,
+                    message: "Unable to shutdown the VM:\n    #{r}"
             end
           end
         end

--- a/lib/vagrant-vmware-esxi/action/snapshot_delete.rb
+++ b/lib/vagrant-vmware-esxi/action/snapshot_delete.rb
@@ -1,5 +1,5 @@
 require 'log4r'
-require 'net/ssh'
+require_relative 'esxi_connection'
 
 module VagrantPlugins
   module ESXi
@@ -33,32 +33,19 @@ module VagrantPlugins
             env[:ui].info I18n.t('vagrant_vmware_esxi.vagrant_vmware_esxi_message',
                                  message: 'Attempting to snapshot_delete')
 
-            #
-            Net::SSH.start(config.esxi_hostname, config.esxi_username,
-              password:                   config.esxi_password,
-              port:                       config.esxi_hostport,
-              keys:                       config.local_private_keys,
-              timeout:                    20,
-              number_of_password_prompts: 0,
-              non_interactive:            true,
-              keepalive:                  true,
-              keepalive_interval:         30
-            ) do |ssh|
+            r = ESXiConnection.exec!(env,
+                "vim-cmd vmsvc/snapshot.remove #{machine.id} "\
+                "`vim-cmd vmsvc/snapshot.get #{machine.id} | "\
+                "grep -A1 '.*Snapshot Name        : #{env[:snapshot_name]}$' | "\
+                "grep 'Snapshot Id'|awk '{print $NF}'`")
 
-              r = ssh.exec!(
-                  "vim-cmd vmsvc/snapshot.remove #{machine.id} "\
-                  "`vim-cmd vmsvc/snapshot.get #{machine.id} | "\
-                  "grep -A1 '.*Snapshot Name        : #{env[:snapshot_name]}$' | "\
-                  "grep 'Snapshot Id'|awk '{print $NF}'`")
-
-              if r.exitstatus != 0
-                raise Errors::ESXiError,
-                      message: "Unable to remove snapshots of the VM:\n"\
-                               "  #{r}"
-              end
-
-              env[:ui].info I18n.t('vagrant_vmware_esxi.snapshot_deleted')
+            if r.exitstatus != 0
+              raise Errors::ESXiError,
+                    message: "Unable to remove snapshots of the VM:\n"\
+                             "  #{r}"
             end
+
+            env[:ui].info I18n.t('vagrant_vmware_esxi.snapshot_deleted')
           end
         end
       end

--- a/lib/vagrant-vmware-esxi/action/snapshot_list.rb
+++ b/lib/vagrant-vmware-esxi/action/snapshot_list.rb
@@ -1,5 +1,5 @@
 require 'log4r'
-require 'net/ssh'
+require_relative 'esxi_connection'
 
 module VagrantPlugins
   module ESXi
@@ -30,29 +30,18 @@ module VagrantPlugins
            env[:ui].info I18n.t('vagrant_vmware_esxi.vagrant_vmware_esxi_message',
                                 message: 'Cannot snapshot_list in this state')
           else
+            r = ESXiConnection.exec!(env,
+                "vim-cmd vmsvc/snapshot.get #{machine.id} 2>&1 | "\
+                "grep 'Snapshot Name'|sed 's/.*Snapshot Name        : //g'")
 
-            Net::SSH.start(config.esxi_hostname, config.esxi_username,
-              password:                   config.esxi_password,
-              port:                       config.esxi_hostport,
-              keys:                       config.local_private_keys,
-              timeout:                    20,
-              number_of_password_prompts: 0,
-              non_interactive:            true
-            ) do |ssh|
-
-              r = ssh.exec!(
-                  "vim-cmd vmsvc/snapshot.get #{machine.id} 2>&1 | "\
-                  "grep 'Snapshot Name'|sed 's/.*Snapshot Name        : //g'")
-
-              allsnapshots = r
-              if r.exitstatus != 0
-                raise Errors::ESXiError,
-                      message: "Unable to list snapshots:\n"\
-                               "  #{allsnapshots}\n#{r.stderr}"
-              end
-
-              env[:machine_snapshot_list] = allsnapshots.split("\n")
+            allsnapshots = r
+            if r.exitstatus != 0
+              raise Errors::ESXiError,
+                    message: "Unable to list snapshots:\n"\
+                             "  #{allsnapshots}\n#{r.stderr}"
             end
+
+            env[:machine_snapshot_list] = allsnapshots.split("\n")
           end
         end
       end

--- a/lib/vagrant-vmware-esxi/action/snapshot_restore.rb
+++ b/lib/vagrant-vmware-esxi/action/snapshot_restore.rb
@@ -1,5 +1,5 @@
 require 'log4r'
-require 'net/ssh'
+require_relative 'esxi_connection'
 
 module VagrantPlugins
   module ESXi
@@ -33,33 +33,20 @@ module VagrantPlugins
             env[:ui].info I18n.t('vagrant_vmware_esxi.vagrant_vmware_esxi_message',
                                  message: 'Attempting to snapshot_restore')
 
-            #
-            Net::SSH.start(config.esxi_hostname, config.esxi_username,
-              password:                   config.esxi_password,
-              port:                       config.esxi_hostport,
-              keys:                       config.local_private_keys,
-              timeout:                    20,
-              number_of_password_prompts: 0,
-              non_interactive:            true,
-              keepalive:                  true,
-              keepalive_interval:         30
-            ) do |ssh|
+            r = ESXiConnection.exec!(env,
+                "vim-cmd vmsvc/snapshot.revert #{machine.id} "\
+                "`vim-cmd vmsvc/snapshot.get #{machine.id} | "\
+                "grep -A1 '.*Snapshot Name        : #{env[:snapshot_name]}$' | "\
+                "grep 'Snapshot Id'|awk '{print $NF}'` suppressPowerOn")
 
-              r = ssh.exec!(
-                  "vim-cmd vmsvc/snapshot.revert #{machine.id} "\
-                  "`vim-cmd vmsvc/snapshot.get #{machine.id} | "\
-                  "grep -A1 '.*Snapshot Name        : #{env[:snapshot_name]}$' | "\
-                  "grep 'Snapshot Id'|awk '{print $NF}'` suppressPowerOn")
-
-              config.saved_ipaddress = nil
-              if r.exitstatus != 0
-                raise Errors::ESXiError,
-                      message: "Unable to restore snapshots of the VM:\n"\
-                               "  #{r}"
-              end
-
-              env[:ui].info I18n.t('vagrant_vmware_esxi.snapshot_restored')
+            config.saved_ipaddress = nil
+            if r.exitstatus != 0
+              raise Errors::ESXiError,
+                    message: "Unable to restore snapshots of the VM:\n"\
+                             "  #{r}"
             end
+
+            env[:ui].info I18n.t('vagrant_vmware_esxi.snapshot_restored')
           end
         end
       end

--- a/lib/vagrant-vmware-esxi/action/snapshot_save.rb
+++ b/lib/vagrant-vmware-esxi/action/snapshot_save.rb
@@ -1,5 +1,5 @@
 require 'log4r'
-require 'net/ssh'
+require_relative 'esxi_connection'
 
 module VagrantPlugins
   module ESXi
@@ -34,54 +34,41 @@ module VagrantPlugins
             env[:ui].info I18n.t('vagrant_vmware_esxi.vagrant_vmware_esxi_message',
                                  message: 'Attempting to snapshot_save')
 
-            #
-            Net::SSH.start(config.esxi_hostname, config.esxi_username,
-              password:                   config.esxi_password,
-              port:                       config.esxi_hostport,
-              keys:                       config.local_private_keys,
-              timeout:                    20,
-              number_of_password_prompts: 0,
-              non_interactive:            true,
-              keepalive:                  true,
-              keepalive_interval:         30
-            ) do |ssh|
+            env[:ui].info I18n.t('vagrant_vmware_esxi.vagrant_vmware_esxi_message',
+                                 message: "snapshot name      : #{env[:snapshot_name]}")
 
-              env[:ui].info I18n.t('vagrant_vmware_esxi.vagrant_vmware_esxi_message',
-                                   message: "snapshot name      : #{env[:snapshot_name]}")
-
-              if RUBY_PLATFORM =~ /win/i
-                username_msg = ENV['USERNAME'] unless ENV['USERNAME'].nil?
-              else
-                username_msg = ENV['USER'] unless ENV['USER'].nil?
-              end
-              username_msg = "Unknown" if username_msg.nil?
-
-              options_msg = ''
-              options_msg << ' ' + config.guest_snapshot_includememory unless config.guest_snapshot_includememory.nil?
-              options_msg << ' ' + config.guest_snapshot_quiesced unless config.guest_snapshot_quiesced.nil?
-              options_msg = "Options:" + options_msg if options_msg.length > 2
-
-              snapshot_msg = time.localtime.to_s + ", Snapshot created using Vagrant-vmware-esxi by " +\
-                              username_msg + "\n#{options_msg}"
-
-              if config.debug =~ %r{true}i
-                env[:ui].info I18n.t('vagrant_vmware_esxi.vagrant_vmware_esxi_message',
-                                     message: "snapshot_msg: #{snapshot_msg}")
-              end
-
-              r = ssh.exec!("vim-cmd vmsvc/snapshot.create #{machine.id} "\
-                "\"#{env[:snapshot_name]}\" \"#{snapshot_msg}\" "\
-                "#{config.guest_snapshot_includememor} #{config.guest_snapshot_quiesced}")
-
-              if r.exitstatus != 0
-                raise Errors::ESXiError,
-                      message: "Unable to save snapshots of the VM:\n"\
-                               "  #{r}"
-              end
-              env[:ui].info I18n.t('vagrant_vmware_esxi.support')
-
-              env[:ui].info I18n.t('vagrant_vmware_esxi.snapshot_saved')
+            if RUBY_PLATFORM =~ /win/i
+              username_msg = ENV['USERNAME'] unless ENV['USERNAME'].nil?
+            else
+              username_msg = ENV['USER'] unless ENV['USER'].nil?
             end
+            username_msg = "Unknown" if username_msg.nil?
+
+            options_msg = ''
+            options_msg << ' ' + config.guest_snapshot_includememory unless config.guest_snapshot_includememory.nil?
+            options_msg << ' ' + config.guest_snapshot_quiesced unless config.guest_snapshot_quiesced.nil?
+            options_msg = "Options:" + options_msg if options_msg.length > 2
+
+            snapshot_msg = time.localtime.to_s + ", Snapshot created using Vagrant-vmware-esxi by " +\
+                            username_msg + "\n#{options_msg}"
+
+            if config.debug =~ %r{true}i
+              env[:ui].info I18n.t('vagrant_vmware_esxi.vagrant_vmware_esxi_message',
+                                   message: "snapshot_msg: #{snapshot_msg}")
+            end
+
+            r = ESXiConnection.exec!(env, "vim-cmd vmsvc/snapshot.create #{machine.id} "\
+              "\"#{env[:snapshot_name]}\" \"#{snapshot_msg}\" "\
+              "#{config.guest_snapshot_includememor} #{config.guest_snapshot_quiesced}")
+
+            if r.exitstatus != 0
+              raise Errors::ESXiError,
+                    message: "Unable to save snapshots of the VM:\n"\
+                             "  #{r}"
+            end
+            env[:ui].info I18n.t('vagrant_vmware_esxi.support')
+
+            env[:ui].info I18n.t('vagrant_vmware_esxi.snapshot_saved')
           end
         end
       end


### PR DESCRIPTION
- Add ESXiConnection module with shared per-host SSH connections to avoid closing and reopening SSH connections multiple times as it was causing the ESXI server to timeout
- Refactor all actions to use ESXiConnection.exec!()
- Add PowerShell-based network configuration for Windows guests to workaround https://github.com/hashicorp/vagrant/issues/12742
- Disable cloud-init when setting IP addresses for Linux boxes because they take precedence over what configured by vagrant